### PR TITLE
Fix repo path in README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description="Construction of cell-type-specific functional gene network, with SCINET and HumanNetv3",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/your-username/scHumanNet",
+    url="https://github.com/netbiolab/scHumanNet",
     packages=find_packages(where="python"),
     package_dir={"": "python"},
     classifiers=[


### PR DESCRIPTION
This pull request includes a minor update to the `setup.py` file. The change updates the URL for the project repository to reflect the correct organization.

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L14-R14): Updated the `url` field to point to the official repository under the `netbiolab` organization (`https://github.com/netbiolab/scHumanNet`).